### PR TITLE
patchfinder: pipelines: pretty print patches.json

### DIFF
--- a/patchfinder/spiders/pipelines.py
+++ b/patchfinder/spiders/pipelines.py
@@ -8,7 +8,7 @@ class JsonItemPipeline:
 
     def open_spider(self, spider):
         self.file = open(self.file_name, "wb")
-        self.exporter = JsonItemExporter(self.file)
+        self.exporter = JsonItemExporter(self.file, indent=4)
         self.exporter.start_exporting()
 
     def close_spider(self, spider):


### PR DESCRIPTION
patches.json would have a very messy output, and you couldn't make much
sense of it. Use the indent argument to add an indentation of 4 spaces
and pretty print the JSON.

Signed-off-by: Jaskaran Singh <jaskaransingh7654321@gmail.com>